### PR TITLE
71 docker doesnt seem to utilize the ci cache

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ tmp/
 Dockerfile
 build/
 .git/
+.github/

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@ __pycache__/
 tmp/
 Dockerfile
 build/
+.git/

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,6 @@ __pycache__/
 .gitignore
 tmp/
 Dockerfile
-build/
+fakealpm/build/
 .git/
 .github/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,13 +16,6 @@ jobs:
         key: package-cache-${{ github.sha }}
         restore-keys: package-cache-
 
-    - name: Docker cache
-      uses: actions/cache@v3.3.2
-      with:
-        path: /tmp/docker-cache
-        key: docker-cache-${{ github.sha }}
-        restore-keys: docker-cache-
-
     - name: Log in to Docker Hub
       uses: docker/login-action@v3.0.0
       with:
@@ -39,8 +32,8 @@ jobs:
         file: ${{ github.workspace }}/images/PPpackage/Dockerfile
         push: true
         tags: fackop/pppackage
-        cache-from: type=local,src=/tmp/docker-cache
-        cache-to: type=local,dest=/tmp/docker-cache-new
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
     - name: Build and push fackop/pppackage-runc
       uses: docker/build-push-action@v5.0.0
@@ -49,16 +42,11 @@ jobs:
         file: ${{ github.workspace }}/images/PPpackage-runc/Dockerfile
         push: true
         tags: fackop/pppackage-runc
-        cache-from: type=local,src=/tmp/docker-cache
-        cache-to: type=local,dest=/tmp/docker-cache-new
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
     - name: Try run.sh
       run: ./run.sh tmp/ <tmp/input/input-basic.json
 
     - name: See if ldconfig ran
       run: ls -l tmp/PPpackage-runc/containers/$(docker run --rm fackop/pppackage head --lines=1 /etc/machine-id)/root/etc/ld.so.cache
-
-    - name: Move cache (hack)
-      run: |
-        rm -rf /tmp/docker-cache
-        mv /tmp/docker-cache-new /tmp/docker-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,8 +33,8 @@ jobs:
         push: ${{ github.ref_name == 'main' }}
         tags: fackop/pppackage
         outputs: type=docker
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        # cache-from: type=gha
+        # cache-to: type=gha,mode=max
 
     - name: Build and push fackop/pppackage-runc
       uses: docker/build-push-action@v5.0.0
@@ -44,8 +44,8 @@ jobs:
         push: ${{ github.ref_name == 'main' }}
         tags: fackop/pppackage-runc
         outputs: type=docker
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        # cache-from: type=gha
+        # cache-to: type=gha,mode=max
 
     - name: Try run.sh
       run: ./run.sh tmp/ <tmp/input/input-basic.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       with:
         context: ${{ github.workspace }}
         file: ${{ github.workspace }}/images/PPpackage/Dockerfile
-        push: true
+        push: ${{ github.ref_name == 'main' }}
         tags: fackop/pppackage
         cache-from: type=gha
         cache-to: type=gha,mode=max
@@ -40,7 +40,7 @@ jobs:
       with:
         context: ${{ github.workspace }}
         file: ${{ github.workspace }}/images/PPpackage-runc/Dockerfile
-        push: true
+        push: ${{ github.ref_name == 'main' }}
         tags: fackop/pppackage-runc
         cache-from: type=gha
         cache-to: type=gha,mode=max

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ jobs:
         file: ${{ github.workspace }}/images/PPpackage/Dockerfile
         push: ${{ github.ref_name == 'main' }}
         tags: fackop/pppackage
+        outputs: type=docker
         cache-from: type=gha
         cache-to: type=gha,mode=max
 
@@ -42,6 +43,7 @@ jobs:
         file: ${{ github.workspace }}/images/PPpackage-runc/Dockerfile
         push: ${{ github.ref_name == 'main' }}
         tags: fackop/pppackage-runc
+        outputs: type=docker
         cache-from: type=gha
         cache-to: type=gha,mode=max
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,8 @@ jobs:
       uses: actions/cache@v3.3.2
       with:
         path: ${{ github.workspace }}/tmp/cache
-        key: package-cache-${{ github.sha }}
-        restore-keys: package-cache-
+        key: package-cache
+        # restore-keys: package-cache-
 
     - name: Log in to Docker Hub
       uses: docker/login-action@v3.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,10 +31,10 @@ jobs:
         context: ${{ github.workspace }}
         file: ${{ github.workspace }}/images/PPpackage/Dockerfile
         push: ${{ github.ref_name == 'main' }}
-        tags: fackop/pppackage
+        tags: fackop/pppackage:latest
         outputs: type=docker
-        # cache-from: type=gha
-        # cache-to: type=gha,mode=max
+        cache-from: type=registry,ref=fackop/pppackage:buildcache
+        cache-to: type=registry,ref=fackop/pppackage:buildcache,mode=max
 
     - name: Build and push fackop/pppackage-runc
       uses: docker/build-push-action@v5.0.0
@@ -42,10 +42,10 @@ jobs:
         context: ${{ github.workspace }}
         file: ${{ github.workspace }}/images/PPpackage-runc/Dockerfile
         push: ${{ github.ref_name == 'main' }}
-        tags: fackop/pppackage-runc
+        tags: fackop/pppackage-runc:latest
         outputs: type=docker
-        # cache-from: type=gha
-        # cache-to: type=gha,mode=max
+        cache-from: type=registry,ref=fackop/pppackage-runc:buildcache
+        cache-to: type=registry,ref=fackop/pppackage-runc:buildcache,mode=max
 
     - name: Try run.sh
       run: ./run.sh tmp/ <tmp/input/input-basic.json

--- a/PPpackage.py
+++ b/PPpackage.py
@@ -643,6 +643,8 @@ async def main(
     destination_relative_path: Path,
     debug: bool = False,
 ) -> None:
+    print("PPPACKAGEMESSAGE", file=stderr)
+
     requirements_generators_input = json.load(stdin)
 
     requirements, options, generators = parse_input(requirements_generators_input)

--- a/PPpackage.py
+++ b/PPpackage.py
@@ -643,8 +643,6 @@ async def main(
     destination_relative_path: Path,
     debug: bool = False,
 ) -> None:
-    print("PPPACKAGEMESSAGE", file=stderr)
-
     requirements_generators_input = json.load(stdin)
 
     requirements, options, generators = parse_input(requirements_generators_input)


### PR DESCRIPTION
We now use the registry cache, it is more portable and the github one didn't work.

Also the local cache now works with a constant key but not with split restore/save steps.