### PR TITLE
new `update-database` sub interface

### DIFF
--- a/PPpackage_arch.py
+++ b/PPpackage_arch.py
@@ -85,7 +85,6 @@ async def resolve_requirement(
         dependencies.add(dependency)
 
 
-@app.command("update-db")
 async def update_database(cache_path: Path) -> None:
     database_path, _ = get_cache_paths(cache_path)
 
@@ -289,6 +288,7 @@ async def install(
 
 if __name__ == "__main__":
     init(
+        update_database,
         submanagers,
         resolve,
         fetch,

--- a/PPpackage_conan.py
+++ b/PPpackage_conan.py
@@ -38,6 +38,10 @@ from PPpackage_utils import (
 )
 
 
+async def update_database(cache_path: Path) -> None:
+    pass
+
+
 class Options(TypedDict):
     settings: NotRequired[Mapping[str, str]]
     options: NotRequired[Mapping[str, str]]
@@ -499,6 +503,7 @@ async def install(
 
 if __name__ == "__main__":
     init(
+        update_database,
         submanagers,
         resolve,
         fetch,

--- a/PPpackage_sub.py
+++ b/PPpackage_sub.py
@@ -3,6 +3,10 @@ from pathlib import Path
 from typing import Any
 
 
+async def update_database(debug: bool, cache_path: Path) -> None:
+    pass
+
+
 async def resolve(
     debug: bool,
     cache_path: Path,

--- a/PPpackage_utils.py
+++ b/PPpackage_utils.py
@@ -433,6 +433,7 @@ def callback(debug: bool = False) -> None:
 
 
 def init(
+    database_updater: Callable[[Path], Awaitable[None]],
     submanagers_handler: Callable[[], Awaitable[Iterable[str]]],
     resolver: Callable[
         [Path, Iterable[Any], Any], Awaitable[Iterable[Mapping[str, str]]]
@@ -447,6 +448,10 @@ def init(
     lockfile_parser: Callable[[Any], Mapping[str, str]],
     products_parser: Callable[[Any], Set[Product]],
 ) -> None:
+    @app.command("update-database")
+    async def update_database(cache_path: Path) -> None:
+        await database_updater(cache_path)
+
     @app.command()
     async def submanagers() -> None:
         submanagers = await submanagers_handler()

--- a/manager.sh
+++ b/manager.sh
@@ -10,5 +10,4 @@ managers_path="./"
 cache_path="$tmp_path/cache/"
 generators_path="$tmp_path/generators/"
 
-./PPpackage_arch.py update-db "$cache_path" && \
-./PPpackage.py "$managers_path" "$cache_path" "$generators_path" "$daemon_socket_path" "$daemon_workdir_path" "$destination_relative_path" $debug
+./PPpackage.py "$managers_path" "$cache_path" "$generators_path" "$daemon_socket_path" "$daemon_workdir_path" "$destination_relative_path" --update-database $debug


### PR DESCRIPTION
Use `--update-database` to update the databases of all managers before starting the process.